### PR TITLE
Fix to update()

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ Computes the node and link positions for the given *arguments*, returning a *gra
 * *graph*.nodes - the array of [nodes](#sankey_nodes)
 * *graph*.links - the array of [links](#sankey_links)
 
-<a href="#sankey_update" name="sankey_update">#</a> <i>sankey</i>.<b>update</b>(<i>graph</i>) 
+<a href="#sankey_update" name="sankey_update">#</a> <i>sankey</i>.<b>update</b>(<i>graph</i>)
 
 Recomputes the specified *graph*’s links’ positions, updating the following properties of each *link*:
 
 * *link*.y0 - the link’s vertical starting position (at source node)
 * *link*.y1 - the link’s vertical end position (at target node)
+* *link*.circularLinkType - the link's circularLinkType either *top* or *bottom*, depending on whether the center of the connected nodes is above or below the vertical midpoint of the figure.
 
 This method is intended to be called after computing the initial [Sankey layout](#_sankey), for example when the diagram is repositioned interactively.
 

--- a/dist/d3-sankey-circular.js
+++ b/dist/d3-sankey-circular.js
@@ -255,16 +255,6 @@
       //     - x0, x1: the x coordinates, as is relates to visual position from left to right
       // computeNodeDepths(graph)
 
-      // Force position of circular link type based on position
-      graph.links.forEach(function (link) {
-        if (link.circular) {
-          link.circularLinkType = link.y0 + link.y1 < y1 ? 'top' : 'bottom';
-
-          link.source.circularLinkType = link.circularLinkType;
-          link.target.circularLinkType = link.circularLinkType;
-        }
-      });
-
       // 3.  Determine how the circular links will be drawn,
       //     either travelling back above the main chart ("top")
       //     or below the main chart ("bottom")
@@ -274,6 +264,16 @@
       //     Also readjusts sankeyCircular size if circular links are needed, and node x's
       // computeNodeBreadths(graph, iterations, id)
       computeLinkBreadths(graph);
+
+      // Force position of circular link type based on position
+      graph.links.forEach(function (link) {
+        if (link.circular) {
+          link.circularLinkType = link.y0 + link.y1 < y1 ? 'top' : 'bottom';
+
+          link.source.circularLinkType = link.circularLinkType;
+          link.target.circularLinkType = link.circularLinkType;
+        }
+      });
 
       sortSourceLinks(graph, y1, id, false); // Sort links but do not move nodes
       sortTargetLinks(graph, y1, id);

--- a/dist/d3-sankey-circular.mjs
+++ b/dist/d3-sankey-circular.mjs
@@ -253,16 +253,6 @@ function sankeyCircular () {
     //     - x0, x1: the x coordinates, as is relates to visual position from left to right
     // computeNodeDepths(graph)
 
-    // Force position of circular link type based on position
-    graph.links.forEach(function (link) {
-      if (link.circular) {
-        link.circularLinkType = link.y0 + link.y1 < y1 ? 'top' : 'bottom';
-
-        link.source.circularLinkType = link.circularLinkType;
-        link.target.circularLinkType = link.circularLinkType;
-      }
-    });
-
     // 3.  Determine how the circular links will be drawn,
     //     either travelling back above the main chart ("top")
     //     or below the main chart ("bottom")
@@ -272,6 +262,16 @@ function sankeyCircular () {
     //     Also readjusts sankeyCircular size if circular links are needed, and node x's
     // computeNodeBreadths(graph, iterations, id)
     computeLinkBreadths(graph);
+
+    // Force position of circular link type based on position
+    graph.links.forEach(function (link) {
+      if (link.circular) {
+        link.circularLinkType = link.y0 + link.y1 < y1 ? 'top' : 'bottom';
+
+        link.source.circularLinkType = link.circularLinkType;
+        link.target.circularLinkType = link.circularLinkType;
+      }
+    });
 
     sortSourceLinks(graph, y1, id, false); // Sort links but do not move nodes
     sortTargetLinks(graph, y1, id);

--- a/src/sankeyCircular.js
+++ b/src/sankeyCircular.js
@@ -232,6 +232,16 @@ import {linkHorizontal} from "d3-shape";
       //     - x0, x1: the x coordinates, as is relates to visual position from left to right
       // computeNodeDepths(graph)
 
+      // 3.  Determine how the circular links will be drawn,
+      //     either travelling back above the main chart ("top")
+      //     or below the main chart ("bottom")
+      selectCircularLinkTypes(graph, id)
+
+      // 6.  Calculate the nodes' and links' vertical position within their respective column
+      //     Also readjusts sankeyCircular size if circular links are needed, and node x's
+      // computeNodeBreadths(graph, iterations, id)
+      computeLinkBreadths(graph)
+
       // Force position of circular link type based on position
       graph.links.forEach(function (link) {
         if (link.circular) {
@@ -244,19 +254,9 @@ import {linkHorizontal} from "d3-shape";
         }
       })
 
-      // 3.  Determine how the circular links will be drawn,
-      //     either travelling back above the main chart ("top")
-      //     or below the main chart ("bottom")
-      selectCircularLinkTypes(graph, id)
-
-      // 6.  Calculate the nodes' and links' vertical position within their respective column
-      //     Also readjusts sankeyCircular size if circular links are needed, and node x's
-      // computeNodeBreadths(graph, iterations, id)
-      computeLinkBreadths(graph)
-
       sortSourceLinks(graph, y1, id, false) // Sort links but do not move nodes
       sortTargetLinks(graph, y1, id)
-      
+
       // 7.  Sort links per node, based on the links' source/target nodes' breadths
       // 8.  Adjust nodes that overlap links that span 2+ columns
       // var linkSortingIterations = 4; //Possibly let user control this number, like the iterations over node placement


### PR DESCRIPTION
Dear @tomshanley,

On an invocation of `update()`, circular links are forced to a value of top or bottom based on the *previous* position of the center connected nodes. This lead to an inconsistent result. We now force the circular link types based on the *updated* position of the nodes as one would expect.

Thank you!