### PR TITLE
Improve identifyCircle to handle large datasets

### DIFF
--- a/dist/d3-sankey-circular.js
+++ b/dist/d3-sankey-circular.js
@@ -1,8 +1,10 @@
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('d3-array'), require('d3-collection'), require('d3-shape')) :
-  typeof define === 'function' && define.amd ? define(['exports', 'd3-array', 'd3-collection', 'd3-shape'], factory) :
-  (factory((global.d3 = global.d3 || {}),global.d3,global.d3,global.d3));
-}(this, (function (exports,d3Array,d3Collection,d3Shape) { 'use strict';
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('d3-array'), require('d3-collection'), require('d3-shape'), require('elementary-circuits-directed-graph')) :
+  typeof define === 'function' && define.amd ? define(['exports', 'd3-array', 'd3-collection', 'd3-shape', 'elementary-circuits-directed-graph'], factory) :
+  (factory((global.d3 = global.d3 || {}),global.d3,global.d3,global.d3,null));
+}(this, (function (exports,d3Array,d3Collection,d3Shape,findCircuits) { 'use strict';
+
+  findCircuits = findCircuits && findCircuits.hasOwnProperty('default') ? findCircuits['default'] : findCircuits;
 
   // For a given link, return the target node's depth
   function targetDepth(d) {
@@ -42,7 +44,7 @@
     return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
   };
 
-  // https://github.com/tomshanley/d3-sankeyCircular-circular
+  /// https://github.com/tomshanley/d3-sankeyCircular-circular
 
   // sort links' breadth (ie top to bottom in a column), based on their source nodes' breadths
   function ascendingSourceBreadth(a, b) {
@@ -659,19 +661,63 @@
   // Identify circles in the link objects
   function identifyCircles(graph, id, sortNodes) {
 
-    var addedLinks = [];
     var circularLinkID = 0;
 
     if (sortNodes === null) {
 
+      // Building adjacency graph
+      var adjList = [];
+      for (var i = 0; i < graph.links.length; i++) {
+        var link = graph.links[i];
+        var source = getNodeID(link.source, id);
+        var target = getNodeID(link.target, id);
+        if (!adjList[source]) adjList[source] = [];
+        if (!adjList[target]) adjList[target] = [];
+
+        // Add links if not already in set
+        if (adjList[source].indexOf(target) === -1) adjList[source].push(target);
+      }
+
+      // Find all elementary circuits
+      var cycles = findCircuits(adjList);
+
+      // Sort by circuits length
+      cycles.sort(function (a, b) {
+        return a.length - b.length;
+      });
+
+      // Make one link circular for each elementary circuit
+      var circularLinks = {};
+      for (i = 0; i < cycles.length; i++) {
+        var cycle = cycles[i];
+        var closed = false;
+        for (var j = 0; j < cycle.length - 1; j++) {
+          if (!circularLinks[cycle[j]]) circularLinks[cycle[j]] = {};
+
+          // Check if there is already a circular link in the circuit
+          if (circularLinks[cycle[j]] && circularLinks[cycle[j]][cycle[j + 1]]) {
+            closed = true;
+            break;
+          }
+        }
+
+        if (!closed) {
+          // If not closed, make the last link the circular one
+          var last = cycle.slice(-2);
+          circularLinks[last[0]][last[1]] = true;
+        }
+      }
+
       graph.links.forEach(function (link) {
-        if (createsCycle(link.source, link.target, addedLinks, id)) {
+        var target = getNodeID(link.target, id);
+        var source = getNodeID(link.source, id);
+        // If self-linking or a back-edge
+        if (target === source || circularLinks[source] && circularLinks[source][target]) {
           link.circular = true;
           link.circularLinkID = circularLinkID;
           circularLinkID = circularLinkID + 1;
         } else {
           link.circular = false;
-          addedLinks.push(link);
         }
       });
     } else {
@@ -732,55 +778,6 @@
         }
       }
     });
-  }
-
-  // Checks if link creates a cycle
-  function createsCycle(originalSource, nodeToCheck, graph, id) {
-
-    // Check for self linking nodes
-    if (getNodeID(originalSource, id) == getNodeID(nodeToCheck, id)) {
-      return true;
-    }
-
-    if (graph.length == 0) {
-      return false;
-    }
-
-    var nextLinks = findLinksOutward(nodeToCheck, graph);
-    // leaf node check
-    if (nextLinks.length == 0) {
-      return false;
-    }
-
-    // cycle check
-    for (var i = 0; i < nextLinks.length; i++) {
-      var nextLink = nextLinks[i];
-
-      if (nextLink.target === originalSource) {
-        return true;
-      }
-
-      // Recurse
-      if (createsCycle(originalSource, nextLink.target, graph, id)) {
-        return true;
-      }
-    }
-
-    // Exhausted all links
-    return false;
-  }
-
-  // Given a node, find all links for which this is a source in the current 'known' graph
-  function findLinksOutward(node, graph) {
-    var children = [];
-
-    for (var i = 0; i < graph.length; i++) {
-      if (node == graph[i].source) {
-        children.push(graph[i]);
-      }
-    }
-
-    return children;
   }
 
   // Return the angle between a straight line between the source and target of the link, and the vertical plane of the node

--- a/dist/d3-sankey-circular.js
+++ b/dist/d3-sankey-circular.js
@@ -669,8 +669,8 @@
       var adjList = [];
       for (var i = 0; i < graph.links.length; i++) {
         var link = graph.links[i];
-        var source = getNodeID(link.source, id);
-        var target = getNodeID(link.target, id);
+        var source = link.source.index;
+        var target = link.target.index;
         if (!adjList[source]) adjList[source] = [];
         if (!adjList[target]) adjList[target] = [];
 
@@ -709,8 +709,8 @@
       }
 
       graph.links.forEach(function (link) {
-        var target = getNodeID(link.target, id);
-        var source = getNodeID(link.source, id);
+        var target = link.target.index;
+        var source = link.source.index;
         // If self-linking or a back-edge
         if (target === source || circularLinks[source] && circularLinks[source][target]) {
           link.circular = true;
@@ -721,9 +721,7 @@
         }
       });
     } else {
-
       graph.links.forEach(function (link) {
-
         if (link.source[sortNodes] < link.target[sortNodes]) {
           link.circular = false;
         } else {

--- a/dist/d3-sankey-circular.mjs
+++ b/dist/d3-sankey-circular.mjs
@@ -666,8 +666,8 @@ function identifyCircles(graph, id, sortNodes) {
     var adjList = [];
     for (var i = 0; i < graph.links.length; i++) {
       var link = graph.links[i];
-      var source = getNodeID(link.source, id);
-      var target = getNodeID(link.target, id);
+      var source = link.source.index;
+      var target = link.target.index;
       if (!adjList[source]) adjList[source] = [];
       if (!adjList[target]) adjList[target] = [];
 
@@ -706,8 +706,8 @@ function identifyCircles(graph, id, sortNodes) {
     }
 
     graph.links.forEach(function (link) {
-      var target = getNodeID(link.target, id);
-      var source = getNodeID(link.source, id);
+      var target = link.target.index;
+      var source = link.source.index;
       // If self-linking or a back-edge
       if (target === source || circularLinks[source] && circularLinks[source][target]) {
         link.circular = true;
@@ -718,9 +718,7 @@ function identifyCircles(graph, id, sortNodes) {
       }
     });
   } else {
-
     graph.links.forEach(function (link) {
-
       if (link.source[sortNodes] < link.target[sortNodes]) {
         link.circular = false;
       } else {

--- a/dist/d3-sankey-circular.mjs
+++ b/dist/d3-sankey-circular.mjs
@@ -1,6 +1,7 @@
 import { min, ascending, max, mean, sum } from 'd3-array';
 import { map, nest } from 'd3-collection';
 import { linkHorizontal } from 'd3-shape';
+import findCircuits from 'elementary-circuits-directed-graph';
 
 // For a given link, return the target node's depth
 function targetDepth(d) {
@@ -40,7 +41,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
   return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
 };
 
-// https://github.com/tomshanley/d3-sankeyCircular-circular
+/// https://github.com/tomshanley/d3-sankeyCircular-circular
 
 // sort links' breadth (ie top to bottom in a column), based on their source nodes' breadths
 function ascendingSourceBreadth(a, b) {
@@ -657,19 +658,63 @@ function sankeyCircular () {
 // Identify circles in the link objects
 function identifyCircles(graph, id, sortNodes) {
 
-  var addedLinks = [];
   var circularLinkID = 0;
 
   if (sortNodes === null) {
 
+    // Building adjacency graph
+    var adjList = [];
+    for (var i = 0; i < graph.links.length; i++) {
+      var link = graph.links[i];
+      var source = getNodeID(link.source, id);
+      var target = getNodeID(link.target, id);
+      if (!adjList[source]) adjList[source] = [];
+      if (!adjList[target]) adjList[target] = [];
+
+      // Add links if not already in set
+      if (adjList[source].indexOf(target) === -1) adjList[source].push(target);
+    }
+
+    // Find all elementary circuits
+    var cycles = findCircuits(adjList);
+
+    // Sort by circuits length
+    cycles.sort(function (a, b) {
+      return a.length - b.length;
+    });
+
+    // Make one link circular for each elementary circuit
+    var circularLinks = {};
+    for (i = 0; i < cycles.length; i++) {
+      var cycle = cycles[i];
+      var closed = false;
+      for (var j = 0; j < cycle.length - 1; j++) {
+        if (!circularLinks[cycle[j]]) circularLinks[cycle[j]] = {};
+
+        // Check if there is already a circular link in the circuit
+        if (circularLinks[cycle[j]] && circularLinks[cycle[j]][cycle[j + 1]]) {
+          closed = true;
+          break;
+        }
+      }
+
+      if (!closed) {
+        // If not closed, make the last link the circular one
+        var last = cycle.slice(-2);
+        circularLinks[last[0]][last[1]] = true;
+      }
+    }
+
     graph.links.forEach(function (link) {
-      if (createsCycle(link.source, link.target, addedLinks, id)) {
+      var target = getNodeID(link.target, id);
+      var source = getNodeID(link.source, id);
+      // If self-linking or a back-edge
+      if (target === source || circularLinks[source] && circularLinks[source][target]) {
         link.circular = true;
         link.circularLinkID = circularLinkID;
         circularLinkID = circularLinkID + 1;
       } else {
         link.circular = false;
-        addedLinks.push(link);
       }
     });
   } else {
@@ -730,55 +775,6 @@ function selectCircularLinkTypes(graph, id) {
       }
     }
   });
-}
-
-// Checks if link creates a cycle
-function createsCycle(originalSource, nodeToCheck, graph, id) {
-
-  // Check for self linking nodes
-  if (getNodeID(originalSource, id) == getNodeID(nodeToCheck, id)) {
-    return true;
-  }
-
-  if (graph.length == 0) {
-    return false;
-  }
-
-  var nextLinks = findLinksOutward(nodeToCheck, graph);
-  // leaf node check
-  if (nextLinks.length == 0) {
-    return false;
-  }
-
-  // cycle check
-  for (var i = 0; i < nextLinks.length; i++) {
-    var nextLink = nextLinks[i];
-
-    if (nextLink.target === originalSource) {
-      return true;
-    }
-
-    // Recurse
-    if (createsCycle(originalSource, nextLink.target, graph, id)) {
-      return true;
-    }
-  }
-
-  // Exhausted all links
-  return false;
-}
-
-// Given a node, find all links for which this is a source in the current 'known' graph
-function findLinksOutward(node, graph) {
-  var children = [];
-
-  for (var i = 0; i < graph.length; i++) {
-    if (node == graph[i].source) {
-      children.push(graph[i]);
-    }
-  }
-
-  return children;
 }
 
 // Return the angle between a straight line between the source and target of the link, and the vertical plane of the node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-sankey-circular",
-  "version": "0.28.0",
+  "version": "0.30.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1341,6 +1341,14 @@
       "integrity": "sha512-WIZdNuvE3dFr6kkPgv4d/cfswNZD6XbeLBM8baOIQTsnbf4xWrVEaLvp7oNnbnMWWXDqq7Tbv+H5JfciLTJm4Q==",
       "dev": true
     },
+    "elementary-circuits-directed-graph": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.0.2.tgz",
+      "integrity": "sha512-sgZObFWqdmJ0rqXlCbabVE/iZIFWZgP7V5LNwWnxD4Ml7FwxqUUYt8xkLa6rRScIj7d6Ln6/+ZKCc+gTLVA6GA==",
+      "requires": {
+        "strongly-connected-components": "^1.0.1"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1852,14 +1860,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1874,20 +1880,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2004,8 +2007,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2017,7 +2019,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2032,7 +2033,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2040,14 +2040,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2066,7 +2064,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2147,8 +2144,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2160,7 +2156,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2282,7 +2277,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4454,6 +4448,11 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "strongly-connected-components": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
+      "integrity": "sha1-CSDitN9nyOrulsa2I0/inoc9upk="
     },
     "supports-color": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "d3-array": "^1.2.1",
     "d3-collection": "^1.0.4",
-    "d3-shape": "^1.2.0"
+    "d3-shape": "^1.2.0",
+    "elementary-circuits-directed-graph": "^1.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/sankeyCircular.js
+++ b/src/sankeyCircular.js
@@ -673,8 +673,8 @@ import findCircuits from "elementary-circuits-directed-graph";
       var adjList = []
       for (var i = 0; i < graph.links.length; i++) {
           var link = graph.links[i];
-          var source = getNodeID(link.source, id);
-          var target = getNodeID(link.target, id);
+          var source = link.source.index;
+          var target = link.target.index;
           if (!adjList[source]) adjList[source] = []
           if (!adjList[target]) adjList[target] = []
 
@@ -713,8 +713,8 @@ import findCircuits from "elementary-circuits-directed-graph";
       }
 
       graph.links.forEach(function (link) {
-        var target = getNodeID(link.target, id);
-        var source = getNodeID(link.source, id);
+        var target = link.target.index;
+        var source = link.source.index;
         // If self-linking or a back-edge
         if (target === source || (circularLinks[source] && circularLinks[source][target])) {
           link.circular = true
@@ -726,9 +726,7 @@ import findCircuits from "elementary-circuits-directed-graph";
       })
 
     } else {
-
       graph.links.forEach(function(link) {
-
         if (link.source[sortNodes] < link.target[sortNodes]) {
           link.circular = false
         } else {


### PR DESCRIPTION
The `identifyCircle` routine would sometimes get stuck when using large datasets made of thousands of links. By using [Johnson's algorithm to find elementary circuits in a directed graph](https://www.cs.tufts.edu/comp/150GA/homeworks/hw1/Johnson%2075.PDF) we can improve on this.