### PR TITLE
Update version of package `elementary-circuits-directed-graph`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-sankey-circular",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1342,9 +1342,9 @@
       "dev": true
     },
     "elementary-circuits-directed-graph": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.0.2.tgz",
-      "integrity": "sha512-sgZObFWqdmJ0rqXlCbabVE/iZIFWZgP7V5LNwWnxD4Ml7FwxqUUYt8xkLa6rRScIj7d6Ln6/+ZKCc+gTLVA6GA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.0.4.tgz",
+      "integrity": "sha512-+xpVxSimU+fcHiTRPWrRN1IFOKaygwotCtZGSBle/rnFaFAoI+4Y8/pimAY1cKiDIHTek2Zox1R7SEQAB/AQ1g==",
       "requires": {
         "strongly-connected-components": "^1.0.1"
       }
@@ -1860,14 +1860,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1882,20 +1880,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2012,8 +2007,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2025,7 +2019,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2040,7 +2033,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2048,14 +2040,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2074,7 +2064,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2155,8 +2144,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2168,7 +2156,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2290,7 +2277,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "d3-array": "^1.2.1",
     "d3-collection": "^1.0.4",
     "d3-shape": "^1.2.0",
-    "elementary-circuits-directed-graph": "^1.0.2"
+    "elementary-circuits-directed-graph": "^1.0.4"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Some (older) browsers may have issues with `Set` and `Map` which are used in `elementary-circuits-directed-graph`.

Those were removed in version `1.0.4` of the package `elementary-circuits-directed-graph` in this commit https://github.com/antoinerg/elementary-circuits-directed-graph/commit/edd2a81756506dc95fae50b9c7abe8a9187f03c3 .