### PR TITLE
Don't use mjs for module dist yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/tomshanley/d3-sankey-circular.git"
   },
   "main": "dist/d3-sankey-circular.js",
-  "module": "dist/d3-sankey-circular.mjs",
+  "module": "dist/d3-sankey-circular.es.js",
   "dependencies": {
     "d3-array": "^1.2.1",
     "d3-collection": "^1.0.4",


### PR DESCRIPTION
See: #32

This is the easiest solution to fix issues with default config of Webpack. Background:

> Files ending with `.mjs` are parsed as `javascript/esm`, a stricter mode. This mode does not allow to import CJS modules like ESM ones.
> 
> While this issue looks like a webpack one, it is not: `react-apollo` should correctly import non-ESM dependencies, in this case `react`.

From: https://github.com/apollographql/react-apollo/issues/1737

> Just remember Webpack's defaults are the way they are for a reason. `.mjs` is limited because it's not fully baked and it's support story isn't finished yet. If you need `javascript/auto` you should really be using `.js`.

From: https://github.com/apollographql/react-apollo/issues/1737#issuecomment-373039056

I think this is a better solution than having people customize their webpack config, especially since webpack's is trying to be zero config and people using tools like create-react-app, vue-cli who might not even realize that they are using webpack.

Ideally [`d3-array`](https://github.com/d3/d3-array), [`d3-collection`](https://github.com/d3/d3-collection), and [`d3-shape`](https://github.com/d3/d3-shape) start including a `es` format es well, but that will take time. 