### PR TITLE
Fixed sorting of nodes by columns

### DIFF
--- a/dist/d3-sankey-circular.es.js
+++ b/dist/d3-sankey-circular.es.js
@@ -440,7 +440,7 @@ function sankeyCircular () {
 
     // assign column numbers, and get max value
     graph.nodes.forEach(function (node) {
-      node.column = Math.floor(align.call(null, node, x));
+      node.column = sortNodes !== null ? node[sortNodes] : Math.floor(align.call(null, node, x));
     });
   }
 

--- a/dist/d3-sankey-circular.js
+++ b/dist/d3-sankey-circular.js
@@ -443,7 +443,7 @@
 
       // assign column numbers, and get max value
       graph.nodes.forEach(function (node) {
-        node.column = Math.floor(align.call(null, node, x));
+        node.column = sortNodes !== null ? node[sortNodes] : Math.floor(align.call(null, node, x));
       });
     }
 

--- a/dist/d3-sankey-circular.js
+++ b/dist/d3-sankey-circular.js
@@ -189,7 +189,10 @@
         sortTargetLinks(graph, y1, id);
       }
 
-      // 8.1  Adjust node and link positions back to fill height of chart area if compressed
+      // 8.1  Fix nodes overlapping after sortNodes
+      resolveNodesOverlap(graph, y0, py);
+
+      // 8.2  Adjust node and link positions back to fill height of chart area if compressed
       fillHeight(graph, y0, y1);
 
       // 9. Calculate visually appealling path for the circular paths, and create the "d" string
@@ -1488,6 +1491,41 @@
         link.width = link.width * ratio;
       });
     }
+  }
+
+  function resolveNodesOverlap(graph, y0, py) {
+    var columns = d3Collection.nest().key(function (d) {
+      return d.column;
+    }).sortKeys(d3Array.ascending).entries(graph.nodes).map(function (d) {
+      return d.values;
+    });
+
+    columns.forEach(function (nodes) {
+      var node,
+          dy,
+          y = y0,
+          n = nodes.length,
+          i;
+      // Push any overlapping nodes down.
+      nodes.sort(ascendingBreadth);
+
+      for (i = 0; i < n; ++i) {
+        node = nodes[i];
+        dy = y - node.y0;
+
+        if (dy > 0) {
+          node.y0 += dy;
+          node.y1 += dy;
+          node.targetLinks.forEach(function (l) {
+            l.y1 = l.y1 + dy;
+          });
+          node.sourceLinks.forEach(function (l) {
+            l.y0 = l.y0 + dy;
+          });
+        }
+        y = node.y1 + py;
+      }
+    });
   }
 
   exports.sankeyCircular = sankeyCircular;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-sankey-circular",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/sankeyCircular.js
+++ b/src/sankeyCircular.js
@@ -150,7 +150,10 @@ import findCircuits from "elementary-circuits-directed-graph";
 
       }
 
-      // 8.1  Adjust node and link positions back to fill height of chart area if compressed
+      // 8.1  Fix nodes overlapping after sortNodes
+      resolveNodesOverlap(graph, y0, py)
+
+      // 8.2  Adjust node and link positions back to fill height of chart area if compressed
       fillHeight(graph, y0, y1)
 
       // 9. Calculate visually appealling path for the circular paths, and create the "d" string
@@ -1670,4 +1673,38 @@ import findCircuits from "elementary-circuits-directed-graph";
       })
     }
 
+  }
+
+  function resolveNodesOverlap(graph, y0, py){
+    var columns = nest()
+      .key(function (d) {
+        return d.column
+      })
+      .sortKeys(ascending)
+      .entries(graph.nodes)
+      .map(function (d) {
+        return d.values
+      })
+
+      columns.forEach(function (nodes) {
+        var node, dy, y = y0, n = nodes.length, i
+        // Push any overlapping nodes down.
+        nodes.sort(ascendingBreadth)
+
+        for (i = 0; i < n; ++i) {
+          node = nodes[i]
+          dy = y - node.y0
+
+          if (dy > 0) {
+            node.y0 += dy
+            node.y1 += dy
+            node.targetLinks.forEach(function (l) {
+              l.y1 = l.y1 + dy
+            })
+            node.sourceLinks.forEach(function (l) {
+              l.y0 = l.y0 + dy
+            })
+          }
+          y = node.y1 + py
+        }})
   }

--- a/src/sankeyCircular.js
+++ b/src/sankeyCircular.js
@@ -433,7 +433,7 @@ import findCircuits from "elementary-circuits-directed-graph";
 
       // assign column numbers, and get max value
       graph.nodes.forEach(function (node) {
-        node.column = Math.floor(align.call(null, node, x))
+        node.column = sortNodes !== null ? node[sortNodes] : Math.floor(align.call(null, node, x))
       })
 
 


### PR DESCRIPTION
closes #46 

Test data is an object `data2` from [example-data.js](https://github.com/tomshanley/d3-sankey-circular/blob/master/example/example-data.js)
Entry point is [exapmle.js](https://github.com/tomshanley/d3-sankey-circular/blob/master/example/example.js)
>  If sortNodes is defined, then use the sort order of nodes to determine the column.

sankeyCircular config contains `sortNodes("col")`: 
```javascript
    var sankey = d3.sankeyCircular()
      .nodeWidth(10)
      .nodePadding(20) //note that this will be overridden by nodePaddingRatio
      //.nodePaddingRatio(0.5)
      .size([width, height])
      .nodeId(function (d) {
        return d.name;
      })
      .nodeAlign(d3.sankeyJustify)
      .iterations(5)
      .circularLinkGap(1)
      .sortNodes("col")
```
 I suggest looking at the changes that my commits make.
 
- current master, nodes sorting by `col` doesn't work:
![image](https://user-images.githubusercontent.com/22459057/108855887-20eefa00-75f2-11eb-93eb-e37f2b85162c.png)

- 51001ce,  nodes sorting by `col` work well but small overlaps of nodes appear on top of each other:
![image](https://user-images.githubusercontent.com/22459057/108856053-51cf2f00-75f2-11eb-9759-a283cae331fa.png)

- 95c799a, sorting nodes by columns works well, no overlaps were found
![image](https://user-images.githubusercontent.com/22459057/108856081-5a276a00-75f2-11eb-8fce-d5ed5cffbeb4.png)



