### PR TITLE
added function export addCircularPathData

### DIFF
--- a/dist/d3-sankey-circular.es.js
+++ b/dist/d3-sankey-circular.es.js
@@ -1487,4 +1487,4 @@ function fillHeight(graph, y0, y1) {
   }
 }
 
-export { sankeyCircular, center as sankeyCenter, left as sankeyLeft, right as sankeyRight, justify as sankeyJustify };
+export { sankeyCircular, addCircularPathData, center as sankeyCenter, left as sankeyLeft, right as sankeyRight, justify as sankeyJustify };

--- a/dist/d3-sankey-circular.js
+++ b/dist/d3-sankey-circular.js
@@ -1491,6 +1491,7 @@
   }
 
   exports.sankeyCircular = sankeyCircular;
+  exports.addCircularPathData = addCircularPathData;
   exports.sankeyCenter = center;
   exports.sankeyLeft = left;
   exports.sankeyRight = right;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
-export { default as sankeyCircular } from './sankeyCircular.js'
+export {
+  default as sankeyCircular,
+  addCircularPathData,
+} from "./sankeyCircular.js";
 export {
   center as sankeyCenter,
   left as sankeyLeft,
   right as sankeyRight,
-  justify as sankeyJustify
-} from './align'
+  justify as sankeyJustify,
+} from "./align";

--- a/src/sankeyCircular.js
+++ b/src/sankeyCircular.js
@@ -872,7 +872,7 @@ import findCircuits from "elementary-circuits-directed-graph";
   }
 
   // calculate the optimum path for a link to reduce overlaps
-  function addCircularPathData (graph, circularLinkGap, y1, id) {
+ export function addCircularPathData (graph, circularLinkGap, y1, id) {
     //var baseRadius = 10
     var buffer = 5
     //var verticalMargin = 25


### PR DESCRIPTION
**This pull request adds the ability to use `addCircularPathData` functions outside of the main package.**

For example, this function can be used outside the main package in the case when we use the integration of `react` and `d3`, then we use `addCircularPathData`on the graph to recalculate the coordinates of circular links after changing the coordinates of the source or target node.