### PR TITLE
Allow sankeys made of a single node with a circular link

### DIFF
--- a/dist/d3-sankey-circular.es.js
+++ b/dist/d3-sankey-circular.es.js
@@ -405,7 +405,7 @@ function sankeyCircular () {
     y1 = y1 * scaleY;
 
     graph.nodes.forEach(function (node) {
-      node.x0 = x0 + node.column * ((x1 - x0 - dx) / maxColumn);
+      node.x0 = maxColumn > 0 ? x0 + node.column * ((x1 - x0 - dx) / maxColumn) : x0;
       node.x1 = node.x0 + dx;
     });
 
@@ -1474,7 +1474,6 @@ function fillHeight(graph, y0, y1) {
   }
 }
 
-
 function resolveNodesOverlap(graph, y0, py) {
   var columns = nest().key(function (d) {
     return d.column;
@@ -1511,4 +1510,3 @@ function resolveNodesOverlap(graph, y0, py) {
 }
 
 export { sankeyCircular, addCircularPathData, center as sankeyCenter, left as sankeyLeft, right as sankeyRight, justify as sankeyJustify };
-

--- a/dist/d3-sankey-circular.js
+++ b/dist/d3-sankey-circular.js
@@ -408,7 +408,7 @@
       y1 = y1 * scaleY;
 
       graph.nodes.forEach(function (node) {
-        node.x0 = x0 + node.column * ((x1 - x0 - dx) / maxColumn);
+        node.x0 = maxColumn > 0 ? x0 + node.column * ((x1 - x0 - dx) / maxColumn) : x0;
         node.x1 = node.x0 + dx;
       });
 

--- a/src/sankeyCircular.js
+++ b/src/sankeyCircular.js
@@ -389,7 +389,7 @@ import findCircuits from "elementary-circuits-directed-graph";
       y1 = y1 * scaleY;
 
       graph.nodes.forEach(function (node) {
-        node.x0 = x0 + (node.column * ((x1 - x0 - dx) / maxColumn))
+        node.x0 = maxColumn > 0 ? (x0 + (node.column * ((x1 - x0 - dx) / maxColumn))) : x0;
         node.x1 = node.x0 + dx
       })
 


### PR DESCRIPTION
This PR allows sankeys made of a single node with a circular link.

Without this PR, such scenario would result in a division by zero and no sankey displayed (because of NaN dimensions).

On top of that, I figured out last codebase changes weren't published to npm (probably last npm version is this one https://github.com/tomshanley/d3-sankey-circular/commit/de98c76c7208e8155d8aa61f3eac1c49bc1a92ec).

Thanks a lot!